### PR TITLE
Missing ports for Omada-Controller

### DIFF
--- a/charts/incubator/omada-controller/questions.yaml
+++ b/charts/incubator/omada-controller/questions.yaml
@@ -148,6 +148,62 @@ questions:
                                     type: int
                                     default: 8043
 
+        - variable: comm
+          label: "Omada Controller User HTTPS portal"
+          description: "Omada Controller User HTTPS portal"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{serviceSelector}
+                    - variable: comm
+                      label: "TCP Service Port Configuration"
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 8843
+                              required: true
+                          - variable: advanced
+                            label: "Show Advanced settings"
+                            schema:
+                              type: boolean
+                              default: false
+                              show_subquestions_if: true
+                              subquestions:
+                                - variable: protocol
+                                  label: "Port Type"
+                                  schema:
+                                    type: string
+                                    default: "TCP"
+                                    enum:
+                                      - value: HTTP
+                                        description: "HTTP"
+                                      - value: "HTTPS"
+                                        description: "HTTPS"
+                                      - value: TCP
+                                        description: "TCP"
+                                      - value: "UDP"
+                                        description: "UDP"
+                                - variable: nodePort
+                                  label: "Node Port (Optional)"
+                                  description: "This port gets exposed to the node. Only considered when service type is NodePort, Simple or LoadBalancer"
+                                  schema:
+                                    type: int
+                                    min: 9000
+                                    max: 65535
+                                - variable: targetPort
+                                  label: "Target Port"
+                                  description: "The internal(!) port on the container the Application runs on"
+                                  schema:
+                                    type: int
+                                    default: 8843
+
   - variable: serviceexpert
     group: "Networking and Services"
     label: "Show Expert Config"

--- a/charts/incubator/omada-controller/values.yaml
+++ b/charts/incubator/omada-controller/values.yaml
@@ -26,8 +26,20 @@ service:
   main:
     ports:
       main:
+        enabled: true
         port: 8043
         targetPort: 8043
+        protocol: HTTPS
+   web:
+        enabled: true
+        port: 8880
+        targetPort: 8880
+        protocol: HTTP
+   websecure:
+        enabled: true
+        port: 8843
+        targetPort: 8843
+        protocol: HTTPS    
   omada-tcp:
     enabled: true
     ports:

--- a/charts/incubator/omada-controller/values.yaml
+++ b/charts/incubator/omada-controller/values.yaml
@@ -26,20 +26,16 @@ service:
   main:
     ports:
       main:
-        enabled: true
+        protocol: HTTPS
         port: 8043
         targetPort: 8043
-        protocol: HTTPS
-   web:
-        enabled: true
-        port: 8880
-        targetPort: 8880
-        protocol: HTTP
-   websecure:
+  comm:
+    enabled: true
+    ports:
+      comm:
         enabled: true
         port: 8843
-        targetPort: 8843
-        protocol: HTTPS    
+        targetPor: 8843
   omada-tcp:
     enabled: true
     ports:


### PR DESCRIPTION
Adding missing ports for Omada to work, let me know how off I am lol

**Description**
Adding missing User Portal ports for Omada-Controller, the docker image needs 8088 and 8843


PORTAL_HTTP_PORT | 8088 | 1024-65535 | User portal HTTP port; for ports < 1024, see Unprivileged Ports
-- | -- | -- | --
PORTAL_HTTPS_PORT | 8843 | 1024-65535 | User portal HTTPS port; for ports < 1024, see Unprivileged Ports



**Type of change**

- [ ] Feature/App addition
- [X ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
PORTAL_HTTP_PORT	8088	1024-65535	User portal HTTP port; for ports < 1024, see [Unprivileged Ports](https://github.com/mbentley/docker-omada-controller#unprivileged-ports)
PORTAL_HTTPS_PORT	8843	1024-65535	User portal HTTPS port; for ports < 1024, see [Unprivileged Ports](https://github.com/mbentley/docker-omada-controller#unprivileged-ports)